### PR TITLE
Delete duplicated tags from one module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all deps compile eunit clean
+
+all: deps compile eunit dialyze
+
+deps:
+	rebar g-d u-d
+
+compile:
+	rebar co
+
+eunit:
+	rebar eunit skip_deps=true
+
+dialyze: .rebar/*.plt 
+	rebar dialyze
+
+.rebar/*.plt:
+	rebar build-plt
+
+clean:
+	rebar clean
+	-rm -rf .rebar

--- a/src/pt_chronica.erl
+++ b/src/pt_chronica.erl
@@ -92,8 +92,9 @@ parse_transform(AST, Options) ->
     %% ?PATROL_DEBUG("NEW AST START -------------~n~p~nNEW AST END ---------------~n", [AST5]),
     AST5.
 
+-spec find_implicit_tags(erl_syntax:syntaxTree(), [atom()]) -> [atom()].
 find_implicit_tags([], Acc) ->
-    Acc;
+    lists:usort(Acc);
 find_implicit_tags([{attribute, _, chronica_tag, Param} | Tail], Acc) when is_atom(Param)->
     find_implicit_tags(Tail, [Param | Acc]);
 find_implicit_tags([{attribute, _, chronica_tag, Param} | Tail], Acc) when is_list(Param)->

--- a/src/pt_chronica.erl
+++ b/src/pt_chronica.erl
@@ -218,6 +218,7 @@ fun_arity_three(Priority, Iface, NewTags, Module, Line, File, Acc, String, Args)
             {ast("begin $Chronica_stacktrace_line = erlang:get_stacktrace(), chronica_core:log_fast(@Iface, @Priority, @NewTags, @Module, @Line, @File, pt_macro_define(function_string), $NewStringParam, $NewArgsParam) end.", Line), [NewTags|Acc]}
     end.
 
+detective_stacktrace({var, _, _}, _, _) -> [];
 detective_stacktrace({nil, _}, Positions, _) ->
     lists:reverse(Positions);
 detective_stacktrace({cons, _, {call, _, {remote, _, {atom, _, erlang}, {atom, _, get_stacktrace}}, _}, Tail}, Positions, CurrentPosition) ->

--- a/test/log_usages_test.erl
+++ b/test/log_usages_test.erl
@@ -1,0 +1,65 @@
+%%%----------------------------------------------------------------------------
+%%% -*- coding: utf-8 -*-
+%%% @author Andrew Teplyashin andrew.teplyashin@gmail.com
+%%% @copyright (C) 2015, Eltex
+%%% @doc
+%%% Tests for proof pt_chronica parce_transform worked.
+%%% @end
+%%%----------------------------------------------------------------------------
+-module(log_usages_test).
+
+-ifdef(TEST).
+
+-include("chronica.hrl").
+-export([
+         module_log_without_args_test/0,
+         module_log_with_args_test/0,
+         module_log_with_unicode_test/0,
+         module_with_todo_test/0,
+         module_log_with_env_depend_args_test/0
+        ]).
+
+module_log_without_args_test() ->
+    log:debug("Test string!"),
+    log:trace("Test string!"),
+    log:info("Test string!"),
+    log:warning("Test string!"),
+    log:error("Test string!").
+
+module_log_with_args_test() ->
+    log:debug("Test string with empty args", []),
+    log:trace("Test string with empty args", []),
+    log:info("Test string with empty args", []),
+    log:warning("Test string with empty args", []),
+    log:error("Test string with empty args", []),
+
+    log:debug("Test string with arg ~p", [arg]),
+    log:trace("Test string with arg ~p", [arg]),
+    log:info("Test string with arg ~p", [arg]),
+    log:warning("Test string with arg ~p", [arg]),
+    log:error("Test string with arg ~p", [arg]),
+
+    Format = string:copies("~p, ", 10),
+    _Arg = [ X || X <- lists:seq(1, 10) ],
+    log:debug("Test string with external arg " ++ Format, _Arg),
+    log:trace("Test string with external arg " ++ Format, _Arg),
+    log:info("Test string with external arg " ++ Format, _Arg),
+    log:warning("Test string with external arg " ++ Format, _Arg),
+    log:error("Test string with external arg " ++ Format, _Arg).
+
+module_log_with_unicode_test() ->
+    log:debug("Test string with unicode ☎☢☯", []),
+    log:trace("Test string with unicode ☎☢☯", []),
+    log:info("Test string with unicode ☎☢☯", []),
+    log:warning("Test string with unicode ☎☢☯", []),
+    log:error("Test string with unicode ☎☢☯", []).
+
+module_with_todo_test() ->
+    log:todo("Test todo"),
+    log:todo("Uncorrect todo: ~p", [todo]).
+
+module_log_with_env_depend_args_test() ->
+    log:debug("Stack: %stack ~p", [erlang:get_stacktrace()]),
+    log:debug("Self pid: %pid ~p", [erlang:self()]).
+
+-endif. %% TEST


### PR DESCRIPTION
When multiple definition tags perhaps repeats logs
